### PR TITLE
setup.py: add missing cryptography dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
 	),
 	install_requires=[
 		'asn1crypto',
+		'cryptography',
 	],
 	entry_points={
 		'console_scripts': [


### PR DESCRIPTION
Introduced in 949eb55de18da2a08fea48d4da490e8b69c1ddd3.

Signed-off-by: Sam James <sam@gentoo.org>