### PR TITLE
Handling none and bytes password for pfx

### DIFF
--- a/asysocks/unicomm/common/unissl.py
+++ b/asysocks/unicomm/common/unissl.py
@@ -96,7 +96,9 @@ class UniSSL:
 		from cryptography.hazmat.primitives.serialization.pkcs12 import load_key_and_certificates
 		''' Decrypts the .pfx file to be used with requests. '''
 		pfx = Path(pfx_path).read_bytes()
-		private_key, main_cert, add_certs = load_key_and_certificates(pfx, pfx_password.encode('utf-8'), None)
+		if isinstance(pfx_password, str):
+			pfx_password = pfx_password.encode('utf-8')
+		private_key, main_cert, add_certs = load_key_and_certificates(pfx, pfx_password, None)
 		suffix = '%s.pem' % os.urandom(4).hex()
 		self.__keyfilename = 'key_%s' % suffix
 		self.__certfilename = 'cert_%s' % suffix


### PR DESCRIPTION
If the PFX has no password the function will failed. I tried to use empty string for the value of `pfx_password` but the cryptography lib handle it as a character and not as null.
I added the same check as the [minikerberos lib](https://github.com/skelsec/minikerberos/blob/b0de95f70a46ffd46dcaac4fd06348df7a884819/minikerberos/pkinit.py#L118) to handle it